### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Syntaxes/ANTLR.plist
+++ b/Syntaxes/ANTLR.plist
@@ -419,7 +419,7 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>\\(u\h{4}|.)</string>
+							<string>\\(u[0-9A-Fa-f]{4}|.)</string>
 							<key>name</key>
 							<string>constant.character.escape.antlr</string>
 						</dict>
@@ -452,7 +452,7 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>\\(u\h{4}|.)</string>
+							<string>\\(u[0-9A-Fa-f]{4}|.)</string>
 							<key>name</key>
 							<string>constant.character.escape.antlr</string>
 						</dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.